### PR TITLE
Minor fix and optimization.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -34,7 +34,7 @@ mod_name=Waystone Currencys
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=Camellia License
 # The mod version. See https://semver.org/
-mod_version=1.1.0
+mod_version=1.1.2
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/org/hiedacamellia/wscurrencys/content/waystone/CurrencyRequirementRenderer.java
+++ b/src/main/java/org/hiedacamellia/wscurrencys/content/waystone/CurrencyRequirementRenderer.java
@@ -11,14 +11,15 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
+import org.hiedacamellia.wscurrencys.core.config.WSCCommonConfig;
 
 public class CurrencyRequirementRenderer implements RequirementRenderer<CurrencyWarpRequirement> {
 
     private static final ResourceLocation COIN_COPPER = ResourceLocation.fromNamespaceAndPath("lightmanscurrency", "textures/item/coin_copper.png");
     private static final ResourceLocation COIN_IRON = ResourceLocation.fromNamespaceAndPath("lightmanscurrency", "textures/item/coin_iron.png");
     private static final ResourceLocation COIN_GOLD = ResourceLocation.fromNamespaceAndPath("lightmanscurrency", "textures/item/coin_gold.png");
-    private static final ResourceLocation COIN_DIAMOND = ResourceLocation.fromNamespaceAndPath("lightmanscurrency", "textures/item/coin_diamond.png");
     private static final ResourceLocation COIN_EMERALD = ResourceLocation.fromNamespaceAndPath("lightmanscurrency", "textures/item/coin_emerald.png");
+    private static final ResourceLocation COIN_DIAMOND = ResourceLocation.fromNamespaceAndPath("lightmanscurrency", "textures/item/coin_diamond.png");
     private static final ResourceLocation COIN_NETHERITE = ResourceLocation.fromNamespaceAndPath("lightmanscurrency", "textures/item/coin_netherite.png");
 
     private static Font font(){
@@ -39,31 +40,54 @@ public class CurrencyRequirementRenderer implements RequirementRenderer<Currency
         long c = coreValue%10;coreValue/=10;
         long i = coreValue%10;coreValue/=10;
         long g = coreValue%10;coreValue/=10;
-        long d = coreValue%10;coreValue/=10;
         long e = coreValue%10;coreValue/=10;
+        long d = coreValue%10;coreValue/=10;
         long n = coreValue;
 
         boolean canAfford = currencyWarpRequirement.canAfford(player);
 
-        renderCoin(guiGraphics,x,y,COIN_NETHERITE,(int)n,canAfford);
-        renderCoin(guiGraphics,x,y,COIN_EMERALD,(int)e,canAfford);
-        renderCoin(guiGraphics,x,y,COIN_DIAMOND,(int)d,canAfford);
-        renderCoin(guiGraphics,x,y,COIN_GOLD,(int)g,canAfford);
-        renderCoin(guiGraphics,x,y,COIN_IRON,(int)i,canAfford);
-        renderCoin(guiGraphics,x,y,COIN_COPPER,(int)c,canAfford);
+        if (WSCCommonConfig.RenderHighestDenominationOnly.get()) {
+            long[] coinValues = {n, d, e, g, i, c};
+            ResourceLocation[] coinTextures = {COIN_NETHERITE, COIN_DIAMOND, COIN_EMERALD, COIN_GOLD, COIN_IRON, COIN_COPPER};
 
+            int highestIdx = -1;
+            for (int idx = 0; idx < coinValues.length; idx++) {
+                if (coinValues[idx] > 0) {
+                    highestIdx = idx;
+                    break;
+                }
+            }
 
+            if (highestIdx >= 0) {
+                boolean hasLower = false;
+                for (int idx = highestIdx + 1; idx < coinValues.length; idx++) {
+                    if (coinValues[idx] > 0) {
+                        hasLower = true;
+                        break;
+                    }
+                }
+                renderCoin(guiGraphics, x, y, coinTextures[highestIdx], (int) coinValues[highestIdx], canAfford, hasLower);
+            }
+        } else {
+            renderCoin(guiGraphics,x,y,COIN_NETHERITE,(int)n,canAfford,false);
+            renderCoin(guiGraphics,x,y,COIN_DIAMOND,(int)d,canAfford,false);
+            renderCoin(guiGraphics,x,y,COIN_EMERALD,(int)e,canAfford,false);
+            renderCoin(guiGraphics,x,y,COIN_GOLD,(int)g,canAfford,false);
+            renderCoin(guiGraphics,x,y,COIN_IRON,(int)i,canAfford,false);
+            renderCoin(guiGraphics,x,y,COIN_COPPER,(int)c,canAfford,false);
+        }
 
         pose.popPose();
 
     }
 
-    private void renderCoin(GuiGraphics guiGraphics,int x,int y,ResourceLocation resourceLocation,int count,boolean canAfford) {
+    private void renderCoin(GuiGraphics guiGraphics,int x,int y,ResourceLocation resourceLocation,int count,boolean canAfford,boolean hasLower) {
         if(count==0)return;
-        int width = font().width(String.valueOf(count));
+        String text = hasLower ? count + "+" : String.valueOf(count);
+        int width = font().width(text);
         PoseStack pose = guiGraphics.pose();
         guiGraphics.blit(resourceLocation, x, y, 16, 16, 16, 16, 16, 16);
-        MutableComponent moneyRequirementText = Component.literal(String.valueOf(count));
+        MutableComponent moneyRequirementText = Component.literal(text);
         moneyRequirementText.withStyle(canAfford ? ChatFormatting.GREEN : ChatFormatting.RED);
         guiGraphics.drawString(font(),moneyRequirementText, x + 17, y+font().lineHeight/2, 0xFFFFFFFF, false);
         pose.translate(width+16,0,0);

--- a/src/main/java/org/hiedacamellia/wscurrencys/core/config/WSCCommonConfig.java
+++ b/src/main/java/org/hiedacamellia/wscurrencys/core/config/WSCCommonConfig.java
@@ -11,6 +11,10 @@ public class WSCCommonConfig
             .comment("Enable currency consumption")
             .define("EnableCurrencyConsumption", true);
 
+    public static final ModConfigSpec.BooleanValue RenderHighestDenominationOnly = BUILDER
+            .comment("Only render the highest denomination coin in the waystone requirement display")
+            .define("RenderHighestDenominationOnly", true);
+
     public static final ModConfigSpec SPEC = BUILDER.build();
 
 }


### PR DESCRIPTION
fix: correct emerald and diamond coin rendering order in waystone display;
feat: add RenderHighestDenominationOnly config to simplify coin rendering.

RenderHighestDenominationOnly true(default)
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/15fc8739-0427-43db-8c25-f71dfe735b26" />

RenderHighestDenominationOnly false
<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/7d108caf-40f8-46b1-849f-e242ae59f5a0" />
